### PR TITLE
Fix/excursion waiting list checks

### DIFF
--- a/web/app/plugins/rkg-plugin/includes/RKGeronimoExcursion.php
+++ b/web/app/plugins/rkg-plugin/includes/RKGeronimoExcursion.php
@@ -271,8 +271,9 @@ class RKGeronimoExcursion
                 // set author, in case admin has put organizer as someone else
                 $author = isset($this->post['post_author_override']) ? $this->post['post_author_override'] : $this->post['post_author'];
                 $sql = $this->wpdb->prepare(
-                    "INSERT INTO $tableName (post_id, user_id) ".
-                    "VALUES (%s, %s) ",
+                    // since this does not check if the author is already added
+                    // IGNORE will prevent duplicate error on update of excursion
+                    "INSERT IGNORE INTO $tableName (post_id, user_id) VALUES (%s, %s) ",
                     $this->post['post_ID'],
                     $author
                 );

--- a/web/app/themes/rkg-theme/templates/single-excursion.twig
+++ b/web/app/themes/rkg-theme/templates/single-excursion.twig
@@ -60,37 +60,21 @@
                                     data-name="{{ post.title }}"
                                     data-date="{{ meta.starttime|date('j.n.Y.') }}">Zabilježi se na listu interesa</span>
                         {% endif %}
-                    {% elseif replacements|length > 0 %}
+                    {% else %}
                         {% set freeSpots = meta.limitation - totalParticipants %}
-                        {% if user_waiting_position == 1 and freeSpots > 0 %}
+                        {% if meta.leaders > 0 and freeSpots <= meta.leaders and (user.rc in ['R3', 'R4', 'I1', 'I2', 'I3']) %}
                             <button class="excursion-signup course-signup-button"
                                     data-post="{{ post.ID }}"
                                     data-name="{{ post.title }}"
                                     data-date="{{ meta.starttime|date('j.n.Y.') }}">Prijava</button>
-                            <p><small>Na vrhu si liste interesa i ima slobodno mjesto.</small></p>
-                        {% else %}
-                            <button class="course-disabled-button">Lista interesa postoji</button>
-                            {% if user_waiting_position > 1 %}
-                                <p><small>{{ user_waiting_position }}. si na listi interesa.</small></p>
-                            {% else %}
-                                <p><small>Lista interesa nije prazna - nova prijava nije moguća. Organizator mora ručno dodati osobe sa liste interesa.</small></p>
+                            <p><small>Mjesto rezervirano za voditelje.</small></p>
+                            {% if post.ID in signups.excursions_waiting %}
+                                <span class="excursion-signout-waiting"
+                                        data-post="{{ post.ID }}"
+                                        data-name="{{ post.title }}"
+                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
                             {% endif %}
-                        {% endif %}
-                        
-                        {% if post.ID in signups.excursions_waiting %}
-                            <span class="excursion-signout-waiting"
-                                    data-post="{{ post.ID }}"
-                                    data-name="{{ post.title }}"
-                                    data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
-                        {% elseif user_waiting_position == 0 %}
-                            <span class="excursion-signup-waiting"
-                                    data-post="{{ post.ID }}"
-                                    data-name="{{ post.title }}"
-                                    data-date="{{ meta.starttime|date('j.n.Y.') }}">Zabilježi se na listu interesa</span>
-                        {% endif %}
-                    {% else %}
-                        {% set freeSpots = meta.limitation - totalParticipants %}
-                        {% if meta.leaders > 0 and freeSpots <= meta.leaders and not (user.rc in ['R3', 'R4', 'I1', 'I2', 'I3']) %}
+                        {% elseif meta.leaders > 0 and freeSpots <= meta.leaders and not (user.rc in ['R3', 'R4', 'I1', 'I2', 'I3']) %}
                             <button class="course-disabled-button">Rezervirano za voditelje</button>
                             <p><small>Sva slobodna mjesta su rezervirana za voditelje.</small></p>
                             {% if post.ID in signups.excursions_waiting %}
@@ -99,6 +83,33 @@
                                         data-name="{{ post.title }}"
                                         data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
                             {% else %}
+                                <span class="excursion-signup-waiting"
+                                        data-post="{{ post.ID }}"
+                                        data-name="{{ post.title }}"
+                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Zabilježi se na listu interesa</span>
+                            {% endif %}
+                        {% elseif replacements|length > 0 %}
+                            {% if user_waiting_position == 1 and freeSpots > 0 and not (meta.leaders > 0 and freeSpots <= meta.leaders and not (user.rc in ['R3', 'R4', 'I1', 'I2', 'I3'])) %}
+                                <button class="excursion-signup course-signup-button"
+                                        data-post="{{ post.ID }}"
+                                        data-name="{{ post.title }}"
+                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Prijava</button>
+                                <p><small>Na vrhu si liste interesa i ima slobodno mjesto.</small></p>
+                            {% else %}
+                                <button class="course-disabled-button">Lista interesa postoji</button>
+                                {% if user_waiting_position > 1 %}
+                                    <p><small>{{ user_waiting_position }}. si na listi interesa.</small></p>
+                                {% else %}
+                                    <p><small>Lista interesa nije prazna - nova prijava nije moguća. Organizator mora ručno dodati osobe sa liste interesa.</small></p>
+                                {% endif %}
+                            {% endif %}
+                            
+                            {% if post.ID in signups.excursions_waiting %}
+                                <span class="excursion-signout-waiting"
+                                        data-post="{{ post.ID }}"
+                                        data-name="{{ post.title }}"
+                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                            {% elseif user_waiting_position == 0 %}
                                 <span class="excursion-signup-waiting"
                                         data-post="{{ post.ID }}"
                                         data-name="{{ post.title }}"


### PR DESCRIPTION
Fixed conditional logic in excursion template to properly enforce leader-reserved spots:

- Leaders can now sign up for reserved spots even when waiting list exists
- Non-leaders are blocked from taking leader-reserved spots
- Waiting list users respect leader priority (first-in-line non-leaders can't take leader spots)
- Added proper leader reservation check to waiting list signup condition

Resolves issue where first person on waiting list could bypass leader spot reservations.