### PR TITLE
Hide members-only menu items for logged-out users

### DIFF
--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -605,3 +605,14 @@ function login_url_to_homepage($login_url, $redirect, $force_reauth) {
 
 // Disable admin notification when any user changes password
 add_filter( 'send_password_change_email', '__return_false' );
+
+add_filter('wp_nav_menu_objects', function($items, $args) {
+    if ( !is_user_logged_in() ) {
+        foreach ( $items as $key => $item ) {
+            if ( in_array('members-only', $item->classes) ) {
+                unset($items[$key]);
+            }
+        }
+    }
+    return $items;
+}, 10, 2);


### PR DESCRIPTION
## Summary
Implements conditional menu visibility to hide "Gdje ronimo" and other members-only navigation items from logged-out users, resolving issue #2.

- **Authentication check**: Only displays items with `members-only` class to authenticated users
- **Flexible solution**: Works for any menu item by adding the `members-only` CSS class

## Usage
To hide any menu item from logged-out users:
1. In Appearance → Menus
2. In the top right, click Screen Options → enable CSS Classes
3. Edit the menu item you want restricted and add `members-only` class
4. Item will automatically be hidden for non-authenticated users

Closes #2 - Menu: Display "Gdje ronimo" only if logged in