### PR TITLE
Fix header text elements stacking on wide screens

### DIFF
--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -593,7 +593,7 @@ button
         width: initial
 
 .rkg-header-s1
-    display: inline-block
+    display: block
     margin-bottom: 1.1vw
     font-weight: $bold
     font-size: 1.6rem
@@ -603,7 +603,7 @@ button
         font-size: 3.2vw
 
 .rkg-header-s2
-    display: inline-block
+    display: block
     margin-bottom: 1.5vw
     font-weight: $medium
     font-size: 3.4rem


### PR DESCRIPTION
Header elements `.rkg-header-s1` and `.rkg-header-s2` appear side by side on wide screens instead of stacking vertically due to `display: inline-block` styling.

Changed `display: inline-block` to `display: block` for both header elements to ensure consistent vertical stacking across all screen sizes.

- Verified header text stacks vertically on wide screens
- Confirmed mobile layout remains unchanged (already uses block display)

Fixes #34 
