### PR TITLE
Redesign news page with three-column layout and hierarchical category filtering

### DIFF
--- a/src/js/theme/site.js
+++ b/src/js/theme/site.js
@@ -1,5 +1,54 @@
 /* global rkgTheme Croppie */
 
+// News category filtering functionality
+function initNewsFiltering() {
+    const $categoryFilters = jQuery('.rkg-news-category');
+    const $newsBlocks = jQuery('.news-block');
+
+    if ($categoryFilters.length === 0 || $newsBlocks.length === 0) {
+        return;
+    }
+
+    const parentChildMap = {};
+    $categoryFilters.each(function() {
+        const $filter = jQuery(this);
+        const parentId = $filter.data('parent-id');
+        if (parentId) {
+            if (!parentChildMap[parentId]) {
+                parentChildMap[parentId] = [];
+            }
+            parentChildMap[parentId].push($filter.data('category-id'));
+        }
+    });
+
+    $categoryFilters.on('click', function(e) {
+        e.preventDefault();
+        const $this = jQuery(this);
+        const selectedCategoryId = $this.data('category-id');
+
+        $categoryFilters.removeClass('active');
+        $this.addClass('active');
+
+        if ($this.data('category') === 'all') {
+            $newsBlocks.show();
+            return;
+        }
+
+        const targetIds = $this.data('parent-id') === undefined 
+            ? [selectedCategoryId, ...(parentChildMap[selectedCategoryId] || [])]
+            : [selectedCategoryId];
+
+        $newsBlocks.each(function() {
+            const $block = jQuery(this);
+            const blockCategoryIds = $block.data('category-ids')?.toString().split(',') || [];
+            const hasMatch = targetIds.some(id => blockCategoryIds.includes(id.toString()));
+            
+            $block.toggle(hasMatch);
+        });
+    });
+}
+
+
 jQuery(document).ready(($) => {
     //=require ../../../node_modules/pdf417/bcmath-min.js
     //=require ../../../node_modules/pdf417/pdf417.js
@@ -308,4 +357,6 @@ jQuery(document).ready(($) => {
         $('.rkg-excursion-cal-down').show();
         $('.rkg-excursion-cal-up').hide();
     });
+
+    initNewsFiltering();    
 });

--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -2038,9 +2038,6 @@ input.excursion-btn
     text-transform: uppercase
     font-weight: $bold
 
-.news-block
-    margin-bottom: 3vw
-
 .rkg-news-category-select
     @media (--desktop)
         display: none
@@ -2065,7 +2062,7 @@ a.rkg-news-category-link
 .rkg-category-container
     display: flex
     justify-content: space-between
-    width: 60vw !important
+    width: 50vw !important
     @media (--mobile)
         flex-direction: column
         text-align: center
@@ -2251,3 +2248,155 @@ form#responsibility-survey
 .input-error
     color: $color-title-negative
     margin: 0
+
+/* News 3-column layout */
+.news-layout
+    display: flex
+    gap: 2vw
+    margin-left: 12.5vw
+    margin-right: 5vw
+    @media (--mobile)
+        flex-direction: column
+        margin-left: 0
+        margin-right: 0
+
+.news-main-content
+    flex: 2
+    min-width: 0
+
+.news-sidebar
+    flex: 0 0 25vw
+    @media (--mobile)
+        flex: none
+        width: 100%
+
+/* News grid - 2 columns for main content */
+.col-2-news
+    width: 48%
+    margin: 0 1%
+    float: left
+    @media (--mobile)
+        width: 100%
+        margin: 0 0 5vw
+        float: none
+
+.news-main-content .row
+    @util clearfix
+    margin: 0
+
+/* Categories in sidebar - match rkg-side styling */
+.news-categories-sidebar
+    margin-bottom: 3vw
+    padding-left: 40px
+
+    h2
+        margin-bottom: 1vw
+        color: black
+        text-transform: uppercase
+        font-weight: $bold
+        font-size: 1.2rem
+    
+    ul
+        list-style: none
+        margin-top: 0
+        margin-bottom: 1vw
+        padding: 0
+        
+        li
+            display: block
+            min-height: 1.2vw
+            font-size: 1.1rem
+            
+            a.rkg-news-category
+                display: block
+                margin-bottom: 0.5vw
+                color: $color-main
+                text-decoration: none
+                text-transform: uppercase
+                font-weight: $semi-bold
+                cursor: pointer
+                
+                &:hover
+                    color: color($color-main tint(30%))
+                
+                &.active
+                    color: black
+                    font-weight: $bold
+            ul
+                list-style: none
+                padding-left: 0
+                margin: 0
+                
+                li  
+                    a.rkg-news-category
+                        padding-left: 1vw
+                        margin-bottom: 0.5vw
+                        color: $color-main
+                        text-transform: none
+                        font-weight: $semi-bold
+                        
+                        &:hover
+                            color: color($color-main tint(30%))
+                        
+                        &.active
+                            color: $color-main
+                            font-weight: $bold
+
+        @media (--mobile)
+            padding-left: 0
+            
+            li
+                margin-bottom: 2vw
+                min-height: 2.6vw
+                font-size: 14px
+
+                ul
+                    li
+                        a.rkg-news-category
+                            padding-left: 2vw
+
+    @media (--mobile)
+        padding-left: 0
+
+/* Pagination */
+.news-pagination
+    margin-top: 4vw
+    text-align: center
+    @util clearfix
+    
+    a, span
+        display: inline-block
+        padding: 1vw 1.5vw
+        margin: 0 0.5vw
+        color: $color-main
+        text-decoration: none
+        border: 1px solid color($color-main tint(50%))
+        border-radius: 0.3vw
+        
+        &:hover
+            background: $color-title
+            color: white
+            border-color: $color-title
+    
+    .pagination-current
+        background: $color-title
+        color: white
+        border-color: $color-title
+        font-weight: $bold
+    
+    @media (--mobile)
+        margin-top: 6vw
+        
+        a, span
+            padding: 2vw 3vw
+            font-size: 14px
+
+/* Sidebar adjustments for news layout */
+.news-sidebar .rkg-side
+    float: none
+    margin-right: 0
+    width: 100%
+    
+    @media (--mobile)
+        margin: 0 0 4vw
+        width: 95vw

--- a/web/app/plugins/rkg-plugin/lib/templates/newsBlockContent.twig
+++ b/web/app/plugins/rkg-plugin/lib/templates/newsBlockContent.twig
@@ -4,7 +4,11 @@
             <div class="col-3">
                 <a class="news-block-item" href="{{ post.guid }}" style="background-image: url('{{ post.get_thumbnail.src }}');">
                     <div class="news-block-filter"></div>
-                    <div class="news-block-category">{{ post.categories[0].name }}</div>
+                    <div class="news-block-category">
+                        {% for category in post.categories|slice(0, 3) %}
+                            {{ category.name }}{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                    </div>
                     <h4 class="news-block-title">{{ post.post_title }}</h4>
                 </a>
             </div>

--- a/web/app/themes/rkg-theme/templates/page-news.twig
+++ b/web/app/themes/rkg-theme/templates/page-news.twig
@@ -1,28 +1,30 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="content-wrapper">
-		<article class="post-type-{{post.post_type}}" id="post-{{post.ID}}">
-			<section class="article-content">
-				<h1 class="article-h1">{{post.title}}</h1>
-                <div class="rkg-side">
-                    <h2 class="rkg-toggler" data-toggle="rkg-who-menu">NAVIGACIJA
-                        <span><i class="fas fa-chevron-down rkg-toggler-icon"></i></span>
-                    </h2>
-
-                    <div class="rkg-hidder" id="rkg-who-menu">
-                        {{ rkg_side }}
-                        <hr class="wp-block-separator only-mobile">
-                    </div>
-                </div>
-				<div class="article-body">
-                    <div class="row-container news-content-container">
+    <div class="content-wrapper">
+        <article class="post-type-{{post.post_type}}" id="post-{{post.ID}}">
+            <section class="article-content">
+                <h1 class="article-h1">{{post.title}}</h1>
+                
+                <div class="article-body news-layout">
+                    <div class="news-main-content">
+                        {% set paged = fn('get_query_var', 'paged') ?: 1 %}
+                        {% set offset = (paged - 1) * 8 %}
+                        {% set total_news = news|length %}
+                        {% set paginated_news = news|slice(offset, 8) %}
+                        
                         <div class="row">
-                            {% for new in news %}
-                                <div class="news-block">
-                                    <div class="col-3">
+                            {% for new in paginated_news %}
+                                <div class="news-block" 
+                                    data-categories="{% for category in new.categories %}{{ category.slug }}{% if not loop.last %} {% endif %}{% endfor %}"
+                                    data-category-ids="{% for category in new.categories %}{{ category.term_id }}{% if not loop.last %},{% endif %}{% endfor %}">
+                                    <div class="col-2-news">
                                         <a class="news-block-item" href="{{ new.guid }}" style="background-image: url('{{ new.get_thumbnail.src }}');">
-                                            <div class="news-block-category">{{ new.categories[0].name }}</div>
+                                            <div class="news-block-category">
+                                                {% for category in new.categories|slice(0, 3) %}
+                                                    {{ category.name }}{% if not loop.last %}, {% endif %}
+                                                {% endfor %}
+                                            </div>
                                             <h4 class="news-block-title">{{ new.post_title }}</h4>
                                             <div class="news-block-date">{{ new.post_date|date("j.n.Y H:s") }}</div>
                                         </a>
@@ -30,9 +32,106 @@
                                 </div>
                             {% endfor %}
                         </div>
+                        
+                        <!-- Pagination -->
+                        {% if total_news > 8 %}
+                            <div class="news-pagination">
+                                {% set total_pages = (total_news / 8)|round(0, 'ceil') %}
+                                
+                                {% if paged > 1 %}
+                                    <a href="{{ fn('get_pagenum_link', paged - 1) }}" class="pagination-prev">« Prethodna</a>
+                                {% endif %}
+                                
+                                {% for page in 1..total_pages %}
+                                    {% if page == paged %}
+                                        <span class="pagination-current">{{ page }}</span>
+                                    {% else %}
+                                        <a href="{{ fn('get_pagenum_link', page) }}" class="pagination-page">{{ page }}</a>
+                                    {% endif %}
+                                {% endfor %}
+                                
+                                {% if paged < total_pages %}
+                                    <a href="{{ fn('get_pagenum_link', paged + 1) }}" class="pagination-next">Sljedeća »</a>
+                                {% endif %}
+                            </div>
+                        {% endif %}
                     </div>
-				</div>
-			</section>
-		</article>
-	</div><!-- /content-wrapper -->
+                    
+                    <div class="news-sidebar">
+                        <!-- Categories Filter -->
+                        <div class="news-categories-sidebar">
+                            <h2>KATEGORIJE</h2>
+                            <ul class="menu">
+                                <li><a class="rkg-news-category active" data-category="all" href="#">SVE</a></li>
+                                
+                                {% set all_categories = [] %}
+                                {% set parent_categories = [] %}
+                                {% set child_categories = [] %}
+                                
+                                {% for new in news %}
+                                    {% for category in new.categories %}
+                                        {% if category.term_id not in all_categories %}
+                                            {% set all_categories = all_categories|merge([category.term_id]) %}
+                                            {% if category.parent == 0 %}
+                                                {% set parent_categories = parent_categories|merge([category]) %}
+                                            {% else %}
+                                                {% set child_categories = child_categories|merge([category]) %}
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endfor %}
+                                
+                                {% for parent in parent_categories %}
+                                    <li>
+                                        <a class="rkg-news-category" data-category="{{ parent.slug }}" data-category-id="{{ parent.term_id }}" href="#">{{ parent.name|upper }}</a>
+                                        
+                                        {% set has_children = false %}
+                                        {% for child in child_categories %}
+                                            {% if child.parent == parent.term_id %}
+                                                {% if not has_children %}
+                                                    <ul>
+                                                    {% set has_children = true %}
+                                                {% endif %}
+                                                <li>
+                                                    <a class="rkg-news-category" data-category="{{ child.slug }}" data-category-id="{{ child.term_id }}" data-parent-id="{{ parent.term_id }}" href="#">{{ child.name|upper }}</a>
+                                                </li>
+                                            {% endif %}
+                                        {% endfor %}
+                                        {% if has_children %}
+                                            </ul>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                                
+                                {% for child in child_categories %}
+                                    {% set parent_exists = false %}
+                                    {% for parent in parent_categories %}
+                                        {% if parent.term_id == child.parent %}
+                                            {% set parent_exists = true %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% if not parent_exists %}
+                                        <li>
+                                            <a class="rkg-news-category" data-category="{{ child.slug }}" data-category-id="{{ child.term_id }}" href="#">{{ child.name|upper }}</a>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </div>
+
+                        <!-- Navigation -->
+                        <div class="rkg-side">
+                            <h2 class="rkg-toggler" data-toggle="rkg-who-menu">NAVIGACIJA
+                                <span><i class="fas fa-chevron-down rkg-toggler-icon"></i></span>
+                            </h2>
+                            <div class="rkg-hidder" id="rkg-who-menu">
+                                {{ rkg_side }}
+                                <hr class="wp-block-separator only-mobile">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </article>
+    </div><!-- /content-wrapper -->
 {% endblock %}


### PR DESCRIPTION
Complete redesign of the news page to fix layout issues and improve user experience with proper category hierarchy.

- Replaced problematic float-based layout with flexbox three-column design
- News content now uses 2 columns with proper 48% width distribution
- Sidebar fixed at 25vw width with navigation and categories
- Added proper margins (12.5vw left, 5vw right) for alignment consistency
- Implemented hierarchical category display (parent/child relationships)
- Categories now styled to match existing navigation patterns
- JavaScript filtering to handle parent/child category relationships
- Added pagination with 8 items per page
- **Enhanced category display to show up to 3 categories per post** (previously only showed first category)

#### Performance Considerations
**Note:** Current implementation loads all news posts and uses frontend filtering for instant user experience. This approach prioritizes UX (immediate filtering response) over memory optimization. For typical sites with <500 posts, this provides better user experience than AJAX-based filtering. If dataset grows significantly, implementing backend filtering with loading states should be considered.

Fixes #25 


<img width="2545" height="3930" alt="localhost_8080_aktualno_" src="https://github.com/user-attachments/assets/b3f42b78-3961-4bbc-8849-7f22ece8cc5e" />
