### PR TITLE
Add confirmation dialog for permanent inventory deletion

### DIFF
--- a/src/js/plugin/script.js
+++ b/src/js/plugin/script.js
@@ -916,4 +916,48 @@ jQuery(document).ready(($) => {
 
         hideUnregisterDialog();
     });
+
+    $(document).on('click', '#apply-trash-actions', function(e) {
+        var form = $(this).closest('form');
+        var select = form.find('select[name="action"]');
+        
+        if (select.val() === 'hard_delete') {
+            e.preventDefault();
+            
+            var selectedIds = [];
+            form.find('input[name="ids[]"]:checked').each(function() {
+                selectedIds.push($(this).val());
+            });
+            
+            if (selectedIds.length === 0) {
+                alert('Molimo odaberite stavke za brisanje');
+                return false;
+            }
+            
+            if (confirm('Jeste li sigurni da želite trajno obrisati odabranu opremu? Ova akcija se ne može poništiti.')) {
+                var formData = new FormData();
+                formData.append('action', 'rkg_inventory_hard_delete');
+                selectedIds.forEach(id => formData.append('ids[]', id));
+
+                $.ajax({
+                    url: rkgScript.ajaxUrl,
+                    type: 'POST',
+                    processData: false,
+                    contentType: false,
+                    data: formData,
+                    success: function(response) {
+                        if (response.success) {
+                            location.reload();
+                        } else {
+                            alert('Greška: ' + response.data);
+                        }
+                    },
+                    error: function() {
+                        alert('Dogodila se greška prilikom brisanja.');
+                    }
+                });
+            }
+            return false;
+        }
+    });
 });

--- a/web/app/plugins/rkg-plugin/lib/templates/inventory.twig
+++ b/web/app/plugins/rkg-plugin/lib/templates/inventory.twig
@@ -45,8 +45,19 @@
     </form>
     <form method="get">
         <input type="hidden" name="page" value="inventory_managment" />
-<div class="clear"></div>
-<div class="alignleft actions bulkactions">
+        <div class="clear"></div>
+        {% if request.get.state == '5' %}
+            <div class="alignleft actions bulkactions">
+                <label for="bulk-action-selector-top" class="screen-reader-text">Odaberi grupnu akciju</label>
+                <select name="action" id="bulk-action-selector-top">
+                    <option value="-1">Grupne radnje</option>
+                    <option value="0">Vrati na stanje</option>
+                    <option value="hard_delete" style="color: #dc3232;">Trajno obriši</option>
+                </select>
+                <input type="submit" id="apply-trash-actions" class="button action" value="Primijeni">
+            </div>
+        {% else %}
+            <div class="alignleft actions bulkactions">
                 <label for="bulk-action-selector-top" class="screen-reader-text">Odaberi grupnu akciju</label>
                 <select name="action" id="bulk-action-selector-top">
                     <option value="-1">Grupne radnje</option>
@@ -55,9 +66,11 @@
                     <option value="2">Neispravno</option>
                     <option value="3">Izgubljeno</option>
                     <option value="4">Otpisano</option>
+                    <option value="5">Obriši</option>
                 </select>
                 <input type="submit" id="doaction" class="button action" value="Primijeni">
             </div>
+        {% endif %}
             <br class="clear">
         <table class="wp-list-table widefat fixed striped users" cellspacing="0">
             <thead>
@@ -103,7 +116,7 @@
             <tbody id="the-list" data-wp-lists="list:item">
 
                 {% for item in inventoryItems %}
-                <tr id="item_{{ item.id }}">
+                <tr id="item_{{ item.id }}" {{ (item.state == 5) ? 'style="background-color: #ffebee;"' : '' }}>
                     <th scope="row" class="check-column"><label class="screen-reader-text" for="item_{{ item.id }}">{{ item.id }}</label><input type="checkbox" name="ids[]" id="{{ item.id }}" class="{{ stateTranslation[item.state] }}" value="{{ item.id }}"></th>
                     <td class="id column-id has-row-actions column-primary" data-colname="Id">
                         <strong>


### PR DESCRIPTION
Implements a safe two-step deletion process for inventory items with confirmation dialog to prevent accidental permanent data loss.

- Added two-step deletion workflow:
  1. First step: Move items to "Obrisano" (deleted/trash) state (state = 5)
  2. Second step: Permanently delete items that are already in "Obrisano" state
- Items must first be moved to "Obrisano" state before they can be permanently deleted
- When viewing "Obrisano" items, users see options to "Vrati na stanje" or "Trajno obriši"
- Added confirmation dialog for permanent deletion step
- Added server-side `handleHardDelete()` method with proper validation and security checks
- Enhanced UI to show different bulk actions depending on current item state

<img width="766" height="355" alt="image" src="https://github.com/user-attachments/assets/8b05aaf8-fb58-401c-b7ac-5f685bd457cd" />
<img width="1306" height="388" alt="image" src="https://github.com/user-attachments/assets/fba2b68d-4d44-4b20-b10d-702694cb6368" />


Fixes #16 
