### PR TITLE
Feature: add user profile pictures with crop and resize

### DIFF
--- a/src/js/theme/modal.js
+++ b/src/js/theme/modal.js
@@ -489,6 +489,80 @@ $('#brevet-link').on('click', (e) => {
     $('#brevet').click();
 });
 
+// Profile picture Croppie - square viewport with circle preview
+const profilePictureResize = new Croppie(document.getElementById('profile-picture-crop'), {
+    viewport: {width: 200, height: 200, type: 'circle'},
+    boundary: {width: 300, height: 300},
+    showZoomer: true,
+    enableOrientation: true,
+});
+
+$('.profile-croppie-rotate').on('click', (e) => {
+    profilePictureResize.rotate(parseInt($(e.currentTarget).data('deg'), 10));
+});
+
+function readProfilePictureURL(input) {
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function (e) {
+            modalOpen('#rkg-modal-profile-picture', () => {
+                profilePictureResize.bind({
+                    url: e.target.result,
+                });
+                $('.profile-picture-upload-button').off('click').on('click', () => {
+                    profilePictureResize.result('base64').then((dataImg) => {
+                        const formData = new FormData();
+                        formData.append('action', 'profile_picture_upload');
+                        formData.append('image', dataImg);
+                        jQuery.ajax({
+                            url: rkgScript.ajaxUrl,
+                            type: 'POST',
+                            contentType: false,
+                            processData: false,
+                            data: formData,
+                            success(response) {
+                                if (response.success) {
+                                    // Update profile picture displays on page
+                                    $('.current-profile-picture').attr('src', response.data);
+                                    $('.user-profile-picture').attr('src', response.data);
+                                    modalStatusClass();
+                                    $('.rkg-modal-status').text('Slika profila je spremljena');
+                                    $('body').removeClass('modal-open');
+                                    setTimeout(() => {
+                                        window.location.reload();
+                                    }, 1000);
+                                } else {
+                                    modalStatusClass(1);
+                                    $('.rkg-modal-status').text('Greška: ' + response.data);
+                                }
+                            },
+                            error(error) {
+                                console.log(error);
+                                modalStatusClass(1);
+                                $('.rkg-modal-status').text('Došlo je do greške prilikom uploada');
+                            },
+                        });
+                    });
+                });
+            });
+        };
+        reader.readAsDataURL(input.files[0]);
+    }
+}
+
+$('#profile-picture-input').on('change', function () {
+    if (!window.File || !window.FileReader || !window.FileList || !window.Blob) {
+        alert('The File APIs are not fully supported in this browser.');
+        return;
+    }
+    readProfilePictureURL(this);
+});
+
+$('#profile-picture-link').on('click', (e) => {
+    e.preventDefault();
+    $('#profile-picture-input').click();
+});
+
 $('form#helth-survey').on('submit', (e) => {
     e.preventDefault();
     const formData  = new FormData($('#helth-survey').get(0));

--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -399,6 +399,58 @@ button
             content: ''
             pointer-events: none
 
+.rkg-profile-picture-section
+    text-align: center
+    padding: 1vw
+    border-bottom: 1px solid $color-main
+    @media (--mobile)
+        padding: 3vw
+
+.profile-picture-preview
+    display: inline-block
+    position: relative
+    cursor: pointer
+    .current-profile-picture
+        width: 80px
+        height: 80px
+        border-radius: 50%
+        object-fit: cover
+    .profile-picture-overlay
+        @util position(absolute, 0 0 0 0)
+        display: flex
+        flex-direction: column
+        align-items: center
+        justify-content: center
+        background: color(black a(50%))
+        border-radius: 50%
+        opacity: 0
+        transition: opacity 0.3s ease
+        color: white
+        font-size: 12px
+        i
+            font-size: 20px
+            margin-bottom: 4px
+    &:hover .profile-picture-overlay
+        opacity: 1
+
+.profile-picture-empty
+    width: 80px
+    height: 80px
+    margin: 0 auto
+    display: flex
+    flex-direction: column
+    align-items: center
+    justify-content: center
+    background: $color-title
+    border-radius: 50%
+    color: white
+    cursor: pointer
+    i
+        font-size: 32px
+    span
+        font-size: 10px
+        text-align: center
+
 .dashicons-before::before
     width: 1.1vw !important
     height: 1.1vw !important
@@ -1947,6 +1999,55 @@ h2.courses-terms-control
             display: block
     div:not(:first-child)
         margin-top: 0.5vw
+
+.user-profile-picture
+    width: 32px
+    height: 32px
+    border-radius: 50%
+    object-fit: cover
+    vertical-align: middle
+    margin-right: 8px
+
+.user-profile-picture-placeholder
+    display: inline-flex
+    width: 32px
+    height: 32px
+    border-radius: 50%
+    background: color($color-main tint(70%))
+    color: white
+    align-items: center
+    justify-content: center
+    vertical-align: middle
+    margin-right: 8px
+    font-size: 16px
+
+.user-profile-picture-large
+    width: 80px
+    height: 80px
+    border-radius: 50%
+    object-fit: cover
+    margin-bottom: 0.5vw
+    @media (--mobile)
+        width: 100px
+        height: 100px
+        margin-bottom: 2vw
+
+.user-profile-picture-large-placeholder
+    display: flex
+    width: 80px
+    height: 80px
+    border-radius: 50%
+    background: color($color-main tint(70%))
+    color: white
+    align-items: center
+    justify-content: center
+    margin: 0 auto 0.5vw
+    font-size: 40px
+    @media (--mobile)
+        width: 100px
+        height: 100px
+        margin-bottom: 2vw
+        font-size: 50px
 
 .page-excursion-container
     border: 0.2vw solid white

--- a/web/app/plugins/rkg-plugin/lib/Users.php
+++ b/web/app/plugins/rkg-plugin/lib/Users.php
@@ -44,6 +44,8 @@ class Users implements InitInterface
         add_action('wp_ajax_brevet_upload', array($this, 'brevetUpload'));
         add_action('wp_ajax_nopriv_brevet_upload', array($this, 'brevetUpload'));
 
+        add_action('wp_ajax_profile_picture_upload', array($this, 'profilePictureUpload'));
+
         add_action('wp_ajax_health_survey', array($this, 'helthSurvey'));
         add_action('wp_ajax_nopriv_helth_survey', array($this, 'helthSurvey'));
 
@@ -356,6 +358,110 @@ class Users implements InitInterface
         }
         throw new \Exception('did not match data URI with image data');
 
+        wp_die();
+    }
+
+    /**
+     * profilePictureUpload
+     *
+     * Handles profile picture upload with server-side resizing.
+     * Only available to logged-in users.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
+     */
+    public function profilePictureUpload()
+    {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('Not authorized');
+            wp_die();
+        }
+
+        // phpcs:disable Zend.NamingConventions.ValidVariableName.NotCamelCaps
+        global $current_user;
+        get_currentuserinfo();
+        $userLogin = $current_user->user_login;
+        $userId    = $current_user->ID;
+        // phpcs:enable Zend.NamingConventions.ValidVariableName.NotCamelCaps
+
+        $data = $_POST['image'];
+        if (preg_match('/^data:image\/(\w+);base64,/', $data, $type)) {
+            $data = substr($data, strpos($data, ',') + 1);
+            $type = strtolower($type[1]);
+
+            if (!in_array($type, array('jpg', 'jpeg', 'gif', 'png'))) {
+                wp_send_json_error('Invalid image type');
+                wp_die();
+            }
+
+            $data = base64_decode($data);
+
+            if (false === $data) {
+                wp_send_json_error('Base64 decode failed');
+                wp_die();
+            }
+
+            $uploadDir  = wp_upload_dir();
+            $uploadPath = str_replace(
+                '/',
+                DIRECTORY_SEPARATOR,
+                $uploadDir['path']
+            ).DIRECTORY_SEPARATOR;
+
+            // temp file for processing
+            $tempFile = $uploadPath.'temp_'.md5(microtime()).'.'.$type;
+            file_put_contents($tempFile, $data);
+
+            // server resize using wp image editor
+            $image = wp_get_image_editor($tempFile);
+            if (!is_wp_error($image)) {
+                // resize to 200x200 with crop (square profile picture)
+                $image->resize(200, 200, true);
+                $image->set_quality(85);
+
+                $filename       = 'profile_'.$userLogin.'.'.$type;
+                $hashedFilename = md5($filename.microtime()).'_'.$filename;
+                $finalPath      = $uploadPath.$hashedFilename;
+
+                $saved = $image->save($finalPath);
+
+                // delete temp file
+                unlink($tempFile);
+
+                if (is_wp_error($saved)) {
+                    wp_send_json_error('Image save failed');
+                    wp_die();
+                }
+
+                // delete old profile picture if exists
+                $oldPicture = get_user_meta($userId, 'profile_picture', true);
+                if ($oldPicture) {
+                    $oldPath = str_replace(
+                        $uploadDir['baseurl'],
+                        $uploadDir['basedir'],
+                        $oldPicture
+                    );
+                    if (file_exists($oldPath)) {
+                        unlink($oldPath);
+                    }
+                }
+
+                // Save URL to user meta
+                $pictureUrl = $uploadDir['url'].'/'.basename($hashedFilename);
+                update_user_meta($userId, 'profile_picture', $pictureUrl);
+
+                wp_send_json_success($pictureUrl);
+                wp_die();
+            } else {
+                unlink($tempFile);
+                wp_send_json_error('Image processing failed');
+                wp_die();
+            }
+        }
+
+        wp_send_json_error('Invalid image data');
         wp_die();
     }
 

--- a/web/app/themes/rkg-theme/templates/partial/menus.twig
+++ b/web/app/themes/rkg-theme/templates/partial/menus.twig
@@ -4,6 +4,24 @@
             <div class="rkg-profile-meni-close"></div>
             <a class="rkg-modal-logo" href="{{ function('home_url') }}"><img class="rkg-top-logo" src="{{ site.theme.link }}/assets/img/logo.png" /></a>
         </div>
+        <div class="rkg-profile-picture-section">
+            <input type="file" id="profile-picture-input" accept="image/*" style="display: none;" />
+            {% set profilePicture = function('get_user_meta', user.ID, 'profile_picture', true) %}
+            {% if profilePicture %}
+                <div class="profile-picture-preview" id="profile-picture-link">
+                    <img src="{{ profilePicture }}" class="current-profile-picture" alt="{{ user.display_name }}" />
+                    <div class="profile-picture-overlay">
+                        <i class="fas fa-camera"></i>
+                        <span>Promijeni</span>
+                    </div>
+                </div>
+            {% else %}
+                <div class="profile-picture-preview profile-picture-empty" id="profile-picture-link">
+                    <i class="fas fa-user-circle"></i>
+                    <span>Dodaj sliku</span>
+                </div>
+            {% endif %}
+        </div>
         <div class="rkg-profile-meni-messages">
             <p>Bok {{ user.first_name }}!</p>
             <br>

--- a/web/app/themes/rkg-theme/templates/partial/modals.twig
+++ b/web/app/themes/rkg-theme/templates/partial/modals.twig
@@ -198,6 +198,17 @@
             </div>
             <button class="brevet-upload-button">Postavi</button>
         </div>
+        <div class="modal-div" id="rkg-modal-profile-picture">
+            <p>Upload slike profila</p>
+            <div class="rkg-croppie-container">
+                <div id="profile-picture-crop"></div>
+            </div>
+            <div>
+                <i class="fas fa-undo profile-croppie-rotate" data-deg="90"></i>
+                <i class="fas fa-redo profile-croppie-rotate" data-deg="-90"></i>
+            </div>
+            <button class="profile-picture-upload-button">Postavi</button>
+        </div>
         <div class="modal-div" id="payment-modal">
             <p id="payment-title"></p>
             <div id="payment-barcode"></div>

--- a/web/app/themes/rkg-theme/templates/partial/user.twig
+++ b/web/app/themes/rkg-theme/templates/partial/user.twig
@@ -5,6 +5,21 @@
         {% set nameToDisplay = userDetail.display_name %}
     {% endif %}
 
+    {# Get profile picture URL if user is logged in #}
+    {% set profilePicture = null %}
+    {% if user is not empty and userDetail.ID is defined %}
+        {% set profilePicture = function('get_user_meta', userDetail.ID, 'profile_picture', true) %}
+    {% endif %}
+
+    {# Profile picture in list - only show to logged-in users #}
+    {% if user is not empty and userDetail.ID is defined %}
+        {% if profilePicture %}
+            <img src="{{ profilePicture }}" alt="{{ nameToDisplay }}" class="user-profile-picture" />
+        {% else %}
+            <span class="user-profile-picture-placeholder"><i class="fas fa-user"></i></span>
+        {% endif %}
+    {% endif %}
+
     {{ nameToDisplay }}
 
     {% if user.can('edit_excursions') %}
@@ -12,6 +27,11 @@
             <div class="rkg-info-close"></div>
             <a class="rkg-modal-logo" href="{{ function('home_url') }}"><img class="rkg-top-logo" src="{{ site.theme.link }}/assets/img/logo.png" /></a>
             <div class="rkg-user-details-flex">
+                {% if profilePicture is defined and profilePicture %}
+                    <img src="{{ profilePicture }}" alt="{{ nameToDisplay }}" class="user-profile-picture-large" />
+                {% else %}
+                    <span class="user-profile-picture-large-placeholder"><i class="fas fa-user"></i></span>
+                {% endif %}
                 <table style="text-align: left">
                     <tr class="only-mobile">
                         <th style="text-align: center" colspan="2">


### PR DESCRIPTION
Summary

- Members can upload and crop their own profile picture from the profile menu
- Images are resized server-side to 200×200px (approx 50KB) to avoid storage issues
- Profile pictures are never visible users that are not logged in
- Small thumbnail shown next to member names in participant lists (course and excursion)
- Larger picture shown in the details popup (click on a member name)

Changes

- `Users.php` - New `profile_picture_upload` AJAX handler (auth-only, no nopriv). Uses WordPress `wp_get_image_editor()` for server-side resize/crop. Cleans up old picture on update.
- `modal.js` - Croppie.js integration with circular 200×200 viewport for cropping before upload
- `modals.twig` - Added crop modal
- `menus.twig` - Upload trigger in profile menu (shows current picture or placeholder)
- `user.twig` - Profile picture display in participant lists and details popup

Tested

- Log in as member, open profile menu, upload a profile picture
- Crop modal opens and image can be rotated/zoomed
- uploaded image appears in profile menu (resized, ~200×200px)
- excursion with participants shjows profile pictures next to names
- Clicking a participant name shows details popup that shows a larger version of the picture
- Logged out - no profile pictures are visible anywhere
- Uploading a second picture deletes old file from storage

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile picture upload functionality with built-in cropping and rotation controls for seamless customization
  * Profile pictures now display across user profiles and navigation areas throughout the platform
  * Placeholder avatars provided for users without profile pictures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->