### PR TITLE
fix: asset cache busting and fix mobile menu empty space

### DIFF
--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -375,8 +375,7 @@ button
         > .rkg-profile-meni-item-group
             padding: 1
             margin-bottom: 10vh
-        .rkg-profile-meni-messages
-            min-height: 53vh
+
 
 .rkg-profile-meni-item
     .hover

--- a/web/app/themes/rkg-theme/lib/RKGTheme.php
+++ b/web/app/themes/rkg-theme/lib/RKGTheme.php
@@ -53,7 +53,8 @@ class RKGTheme
         wp_register_style(
             'rkg_css',
             get_template_directory_uri().'/style.css',
-            array('google_fonts', 'Font_Awesome')
+            array('google_fonts', 'Font_Awesome'),
+            filemtime(get_template_directory().'/style.css')
         );
         wp_enqueue_style('rkg_css');
         wp_register_script(
@@ -68,7 +69,7 @@ class RKGTheme
             'rkg-script',
             get_template_directory_uri().'/static/site.js',
             array('jquery'),
-            1.1,
+            filemtime(get_template_directory().'/static/site.js'),
             true
         );
         wp_enqueue_script('rkg-script');


### PR DESCRIPTION
CSS and JS assets were being cached by browsers indefinitely. The JS had a hardcoded version `1.1` and the CSS had no version at all. Replaced both with filemtime() so the version string is derived from the file's last modified timestamp. Every time assets are rebuilt with gulp, the timestamp changes and browsers automatically fetch the new files.  
  
Removed big empty space on mobile menu under menu message. 
