### PR TITLE
fix: mobile menu scroll lock and modal z-index

### DIFF
--- a/src/js/theme/site.js
+++ b/src/js/theme/site.js
@@ -110,6 +110,7 @@ jQuery(document).ready(($) => {
     $('.rkg-profile-meni-switch').on('click', () => {
         if (($(window).width() <= 1080) && (window.devicePixelRatio > 1.5)) {
             $('.rkg-profile-meni').css('left', '0vw');
+            $('body').addClass('modal-open');
             return;
         }
         $('.rkg-profile-meni').animate({
@@ -121,6 +122,7 @@ jQuery(document).ready(($) => {
     $('.rkg-profile-meni-close').on('click', () => {
         if (($(window).width() <= 1080) && (window.devicePixelRatio > 1.5)) {
             $('.rkg-profile-meni').css('left', '-90vw');
+            $('body').removeClass('modal-open');
             return;
         }
         $('.rkg-profile-meni').animate({

--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -19,7 +19,7 @@ body
     font-weight: $light
     font-size: 1.5rem
     &.modal-open
-        /* overflow: hidden */
+        overflow: hidden
     @media (--mobile)
         /* line-height: 1500% */
         font-size: 14px
@@ -58,7 +58,7 @@ button
 
 .rkg-modal-background
     @util position(fixed, 0 0 0 0)
-    z-index: 1010
+    z-index: 1025
     display: none
     background-color: black
     opacity: 0.5
@@ -83,7 +83,7 @@ button
 .rkg-modal
     @util position(fixed, 37.5% null null 50%)
     transform: translate(-50%, -50%)
-    z-index: 1020
+    z-index: 1030
     display: none
     padding: 3vw 6vw
     background: white


### PR DESCRIPTION
Disable page scrolling behind mobile profile menu - weird behavior while menu is open on mobile  
  
Profile picture upload modal was appearing behind the profile menu because both had same z index, raised modal background to 1025 and modal to 1030  
  
Hope it does not break other modals :eyes: 
