### PR TITLE
Correct membership removal

### DIFF
--- a/web/app/themes/rkg-theme/lib/Admin/UsersList.php
+++ b/web/app/themes/rkg-theme/lib/Admin/UsersList.php
@@ -273,7 +273,8 @@ class UsersList
                 );
 
                 $user = new WP_User($userId);
-                $user->set_role('user');
+                $user->remove_role('member');
+                $user->add_role('user');
             }
             $redirectTo = add_query_arg(
                 'bulk_users_processed',


### PR DESCRIPTION
`WP_User::set_role` is going to [remove all previous roles of the user](https://developer.wordpress.org/reference/classes/wp_user/set_role/). Instead of calling `set_role`, we should call `remove_role('member')` and then `add_role('user')`.

Closes #53