### PR TITLE
Implement waiting list notification

### DIFF
--- a/database/migrations/2026_05_30_120000_add_notify_to_excursion_waiting.php
+++ b/database/migrations/2026_05_30_120000_add_notify_to_excursion_waiting.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Migration: add_notify_to_excursion_waiting
+ * Created: 2026-05-30 12:00:00
+ *
+ * Adds a 'notify' column to the rkg_excursion_waiting table
+ * so users can opt in to email notification when a spot
+ * becomes available on a full excursion.
+ */
+
+return [
+    'up' => function($wpdb) {
+        $tableName = $wpdb->prefix . 'rkg_excursion_waiting';
+
+        $column_exists = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE TABLE_SCHEMA = %s
+                AND TABLE_NAME = %s
+                AND COLUMN_NAME = 'notify'",
+                DB_NAME,
+                $tableName
+            )
+        );
+
+        if (empty($column_exists)) {
+            $wpdb->query(
+                "ALTER TABLE {$tableName}
+                ADD COLUMN notify tinyint(1) DEFAULT 0
+                AFTER post_id"
+            );
+        }
+    },
+
+    'down' => function($wpdb) {
+        $tableName = $wpdb->prefix . 'rkg_excursion_waiting';
+
+        $column_exists = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE TABLE_SCHEMA = %s
+                AND TABLE_NAME = %s
+                AND COLUMN_NAME = 'notify'",
+                DB_NAME,
+                $tableName
+            )
+        );
+
+        if (!empty($column_exists)) {
+            $wpdb->query("ALTER TABLE {$tableName} DROP COLUMN notify");
+        }
+    }
+];

--- a/src/js/theme/modal.js
+++ b/src/js/theme/modal.js
@@ -647,6 +647,8 @@ $('.excursion-signout').on('click', (e) => {
 $('.excursion-signup-waiting').on('click', (e) => {
     e.preventDefault();
     const signupId = $(e.currentTarget).data('post');
+    const $btn = $(e.currentTarget);
+    $btn.css('opacity', '0.5');
 
     $.ajax({
         type: 'POST',
@@ -655,9 +657,64 @@ $('.excursion-signup-waiting').on('click', (e) => {
         data: {
             action: 'rkg_user_excursion_signup_waiting',
             post: signupId,
+            notify: 0,
         },
         success: () => {
+            $('#waiting-notify-after-signup').data('post', signupId);
+            $('#waiting-notify-after-signup').prop('checked', false);
             modalOpen('#excursion-signup-waiting-ok');
+        },
+        error: (error) => {
+            console.log(error);
+            $btn.css('opacity', '1');
+        },
+    });
+});
+
+$(document).on('change', '#waiting-notify-after-signup', function () {
+    const $cb = $(this);
+    const postId = $cb.data('post');
+    const notify = $cb.is(':checked') ? 1 : 0;
+
+    if (!postId) return;
+
+    $.ajax({
+        type: 'POST',
+        dataType: 'json',
+        url: rkgTheme.ajaxurl,
+        data: {
+            action: 'rkg_user_excursion_waiting_notify',
+            post: postId,
+            notify,
+        },
+    });
+});
+
+$(document).on('click', '.waiting-notify-toggle', function () {
+    const $icon = $(this);
+    const postId = $icon.data('post');
+    const newNotify = parseInt($icon.attr('data-notify'), 10) === 1 ? 0 : 1;
+
+    if (!postId) return;
+
+    $.ajax({
+        type: 'POST',
+        dataType: 'json',
+        url: rkgTheme.ajaxurl,
+        data: {
+            action: 'rkg_user_excursion_waiting_notify',
+            post: postId,
+            notify: newNotify,
+        },
+        success: () => {
+            $icon.attr('data-notify', newNotify);
+            $icon.toggleClass('fa-bell fa-bell-slash');
+            $icon.attr(
+                'title',
+                newNotify
+                    ? 'Isključi obavijest e-mailom'
+                    : 'Uključi obavijest e-mailom',
+            );
         },
         error: (error) => {
             console.log(error);

--- a/src/sss/style.sss
+++ b/src/sss/style.sss
@@ -1541,6 +1541,18 @@ button
     @media (--mobile)
         font-size: 14px
 
+.waiting-notify-toggle
+    cursor: pointer
+    display: block
+    text-align: center
+    font-size: 1.2rem
+    margin-top: 8px
+    color: $color-main
+    &:hover
+        opacity: 0.7
+    @media (--mobile)
+        font-size: 14px
+
 .article-h1-course
     margin: 0 40vw 1.5vw 12.5vw
     width: 50vw

--- a/web/app/plugins/rkg-plugin/lib/Activator.php
+++ b/web/app/plugins/rkg-plugin/lib/Activator.php
@@ -265,6 +265,7 @@ class Activator
             id mediumint(9) NOT NULL AUTO_INCREMENT PRIMARY KEY,
             user_id mediumint(9) NOT NULL,
             post_id mediumint(9) NOT NULL,
+            notify tinyint(1) DEFAULT 0 NOT NULL,
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
         ) $charsetCollate;";

--- a/web/app/plugins/rkg-plugin/lib/Excursions.php
+++ b/web/app/plugins/rkg-plugin/lib/Excursions.php
@@ -216,4 +216,135 @@ class Excursions implements InitInterface
 
         return $score;
     }
+
+    public static function notifyWaitingList($postId)
+    {
+        global $wpdb;
+
+        error_log('[notifyWaitingList] Called for excursion post_id=' . $postId);
+
+        $metaTable = $wpdb->prefix . 'rkg_excursion_meta';
+        $meta = $wpdb->get_row($wpdb->prepare(
+            "SELECT limitation, registered, waiting, starttime, endtime, "
+            ."deadline, canceled, guests_limit FROM {$metaTable} WHERE id = %d",
+            $postId
+        ));
+
+        if (!$meta) {
+            error_log('[notifyWaitingList] No meta found for post_id=' . $postId);
+            return 0;
+        }
+
+        error_log('[notifyWaitingList] Meta: limitation=' . $meta->limitation
+            . ' canceled=' . $meta->canceled
+            . ' endtime=' . $meta->endtime
+            . ' deadline=' . $meta->deadline);
+
+        // Don't notify if excursion is canceled, in the past, or past deadline
+        if ($meta->canceled) {
+            error_log('[notifyWaitingList] Excursion is canceled, skipping');
+            return 0;
+        }
+
+        $today = current_time('Y-m-d');
+        if ($meta->endtime < $today) {
+            error_log('[notifyWaitingList] Excursion is in the past (endtime=' . $meta->endtime . '), skipping');
+            return 0;
+        }
+        if ($meta->deadline < $today) {
+            error_log('[notifyWaitingList] Deadline has passed (deadline=' . $meta->deadline . '), skipping');
+            return 0;
+        }
+
+        // Count participants (registered includes members + guests if guests_limit)
+        // We need the actual signup count since registered is a cached counter
+        $signupTable = $wpdb->prefix . 'rkg_excursion_signup';
+        $guestTable = $wpdb->prefix . 'rkg_excursion_guest';
+
+        $registeredCount = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$signupTable} WHERE post_id = %d",
+            $postId
+        ));
+
+        if (!empty($meta->guests_limit)) {
+            $guestCount = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT COUNT(*) FROM {$guestTable} WHERE post_id = %d",
+                $postId
+            ));
+            $registeredCount += $guestCount;
+        }
+
+        $freeSpots = (int) $meta->limitation - $registeredCount;
+
+        error_log('[notifyWaitingList] registeredCount=' . $registeredCount
+            . ' freeSpots=' . $freeSpots);
+
+        // No free spots, no notification
+        if ($freeSpots <= 0) {
+            error_log('[notifyWaitingList] No free spots, skipping notification');
+            return 0;
+        }
+
+        // Get waiting list members who opted in
+        $waitingTable = $wpdb->prefix . 'rkg_excursion_waiting';
+        $users = $wpdb->get_results($wpdb->prepare(
+            "SELECT w.user_id, w.created
+            FROM {$waitingTable} w
+            WHERE w.post_id = %d AND w.notify = 1
+            ORDER BY w.created ASC",
+            $postId
+        ));
+
+        error_log('[notifyWaitingList] Waiting list users with notify=1: ' . count($users));
+
+        if (empty($users)) {
+            error_log('[notifyWaitingList] No waiting list users with notify=1, skipping');
+            return 0;
+        }
+
+        $post = get_post($postId);
+        if (!$post) {
+            error_log('[notifyWaitingList] Post not found for id=' . $postId);
+            return 0;
+        }
+
+        $excursionName = $post->post_title;
+        $permalink = get_permalink($postId);
+        $siteName = get_bloginfo('name');
+
+        $subject = sprintf(
+            "RK Geronimo - Oslobodilo se mjesto za izlet: %s",
+            $excursionName
+        );
+
+        error_log('[notifyWaitingList] Subject: ' . $subject);
+        error_log('[notifyWaitingList] Permalink: ' . $permalink);
+
+        $message = sprintf("Bok!"
+            ."\r\n\r\n"
+            ."Oslobodilo se mjesto za izlet \"%s\". Ako i dalje želiš ići možeš se prijaviti na poveznici:\r\n"
+            ."%s\r\n\r\n"
+            ."Tvoj,\r\n"
+            ."RKG web", $excursionName, $permalink);
+
+        $count = 0;
+        foreach ($users as $userRow) {
+            $user = get_userdata($userRow->user_id);
+            if (!$user || empty($user->user_email)) {
+                error_log('[notifyWaitingList] User ' . $userRow->user_id . ' has no valid email, skipping');
+                continue;
+            }
+
+            $headers = array('Content-Type: text/plain; charset=UTF-8', 'From: RK Geronimo <admin@rkg-geronimo.hr>');
+            error_log('[notifyWaitingList] Attempting wp_mail to ' . $user->user_email);
+            $sent = wp_mail($user->user_email, wp_specialchars_decode($subject), $message, $headers);
+            error_log('[notifyWaitingList] wp_mail result: ' . ($sent ? 'true' : 'false'));
+            if ($sent) {
+                $count++;
+            }
+        }
+
+        error_log('[notifyWaitingList] Notified ' . $count . ' waiting list members');
+        return $count;
+    }
 }

--- a/web/app/plugins/rkg-plugin/lib/Users.php
+++ b/web/app/plugins/rkg-plugin/lib/Users.php
@@ -763,6 +763,8 @@ class Users implements InitInterface
         // If guests count in limit, update registered number (decrease)
         if (!empty($excursionStatus->guests_limit)) {
             $wpdb->query("UPDATE $excursionTableName SET registered = registered - 1 WHERE id = {$_POST['post']};");
+
+            Excursions::notifyWaitingList((int) $_POST['post']);
         }
 
         if (!empty($result)) {

--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -285,6 +285,7 @@ function rkg_user_excursion_signup_waiting()
 {
     $info           = array();
     $info['post'] = $_POST['post'];
+    $info['notify'] = !empty($_POST['notify']) ? 1 : 0;
 
     global $wpdb;
     $currentUser = wp_get_current_user();
@@ -294,16 +295,42 @@ function rkg_user_excursion_signup_waiting()
         array(
             'user_id'   => $currentUser->ID,
             'post_id' => $info['post'],
+            'notify'  => $info['notify'],
         )
     );
 
     $tableName = $wpdb->prefix."rkg_excursion_meta";
     $wpdb->query("UPDATE $tableName SET waiting = waiting + 1 WHERE id = {$info['post']};");
 
-    echo json_encode(array('update'=>true, 'message'=>__('Prijava uspješna')));
+    echo json_encode(array('update'=>true, 'message'=>__('Prijava uspješna'), 'notify'=>$info['notify']));
 
     wp_die();
 }
+
+function rkg_user_excursion_waiting_notify()
+{
+    $post_id = intval($_POST['post']);
+    $notify = !empty($_POST['notify']) ? 1 : 0;
+    $user_id = get_current_user_id();
+
+    if (!$user_id || !$post_id) {
+        echo json_encode(array('success' => false));
+        wp_die();
+    }
+
+    global $wpdb;
+    $tableName = $wpdb->prefix . 'rkg_excursion_waiting';
+    $wpdb->update(
+        $tableName,
+        array('notify' => $notify),
+        array('post_id' => $post_id, 'user_id' => $user_id)
+    );
+
+    echo json_encode(array('success' => true, 'notify' => $notify));
+    wp_die();
+}
+
+add_action('wp_ajax_rkg_user_excursion_waiting_notify', 'rkg_user_excursion_waiting_notify');
 
 add_action('wp_ajax_rkg_user_excursion_signup_waiting', 'rkg_user_excursion_signup_waiting');
 
@@ -357,6 +384,8 @@ function rkg_excursion_signout()
     if ($result) {
         $tableName = $wpdb->prefix."rkg_excursion_meta";
         $wpdb->query("UPDATE $tableName SET registered = registered - 1 WHERE id = {$info['post']};");
+
+        RKGeronimo\Excursions::notifyWaitingList($info['post']);
     
         echo json_encode(array('update'=>true, 'message'=>__('odjava uspješna')));
         wp_die();

--- a/web/app/themes/rkg-theme/single-excursion.php
+++ b/web/app/themes/rkg-theme/single-excursion.php
@@ -203,21 +203,20 @@ $context['guests'] = $wpdb->get_results(
 );
 
 $context['user_waiting_position'] = 0;
+$context['user_waiting_notify'] = false;
 if ($current_user_id) {
     $waitingTableName = $wpdb->prefix."rkg_excursion_waiting";
-    // Only compute position if the user actually has a row on the waiting list
-    $created = $wpdb->get_var($wpdb->prepare(
-        "SELECT created FROM $waitingTableName WHERE post_id = %d AND user_id = %d",
+    $waitingRow = $wpdb->get_row($wpdb->prepare(
+        "SELECT created, notify FROM $waitingTableName WHERE post_id = %d AND user_id = %d",
         $post->ID, $current_user_id
     ));
-    if ($created) {
+    if ($waitingRow) {
         $context['user_waiting_position'] = (int) $wpdb->get_var($wpdb->prepare(
             "SELECT COUNT(*) + 1 FROM $waitingTableName
              WHERE post_id = %d AND created < %s",
-            $post->ID, $created
+            $post->ID, $waitingRow->created
         ));
-    } else {
-        $context['user_waiting_position'] = 0;
+        $context['user_waiting_notify'] = (bool) $waitingRow->notify;
     }
 }
 

--- a/web/app/themes/rkg-theme/templates/partial/excursion-waiting-actions.twig
+++ b/web/app/themes/rkg-theme/templates/partial/excursion-waiting-actions.twig
@@ -1,0 +1,8 @@
+<span class="excursion-signout-waiting"
+        data-post="{{ post.ID }}"
+        data-name="{{ post.title }}"
+        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+<i class="waiting-notify-toggle fas {{ user_waiting_notify ? 'fa-bell' : 'fa-bell-slash' }}"
+   data-post="{{ post.ID }}"
+   data-notify="{{ user_waiting_notify ? '1' : '0' }}"
+   title="{{ user_waiting_notify ? 'Isključi obavijest e-mailom' : 'Uključi obavijest e-mailom' }}"></i>

--- a/web/app/themes/rkg-theme/templates/partial/modals.twig
+++ b/web/app/themes/rkg-theme/templates/partial/modals.twig
@@ -180,6 +180,7 @@
             <p>Prijava interesa je zaprimljena.</p>
             <p>Lista je informativnog karaktera za potrebe organizatora,</br> ako dođe do promjene prijavljenih.</p>
             <p><b>U slučaju slobodnog mjesta, potrebno je samostalno se prijaviti na izlet.</b></p>
+            <p><span class="rkg-input-size"><input type="checkbox" id="waiting-notify-after-signup" data-post=""> Obavijesti me e-mailom kada se oslobodi mjesto</span></p>
             <button class="course-signup-ok-close">U redu</button>
         </div>
         <div class="modal-div" id="rkg-moddal-members">

--- a/web/app/themes/rkg-theme/templates/single-excursion.twig
+++ b/web/app/themes/rkg-theme/templates/single-excursion.twig
@@ -57,10 +57,7 @@
                     {% elseif meta.deadline < now|date('Y-m-d') %}
                         <button class="course-disabled-button">Zaključan</button>
                         {% if post.ID in signups.excursions_waiting %}
-                            <span class="excursion-signout-waiting"
-                                    data-post="{{ post.ID }}"
-                                    data-name="{{ post.title }}"
-                                    data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                            {% include 'partial/excursion-waiting-actions.twig' %}
                         {% elseif freeSpots <= 0 %}
                             <span class="excursion-signup-waiting"
                                     data-post="{{ post.ID }}"
@@ -70,10 +67,7 @@
                     {% elseif freeSpots <= 0 %}
                         <button class="course-disabled-button">Popunjen</button>
                         {% if post.ID in signups.excursions_waiting %}
-                            <span class="excursion-signout-waiting"
-                                    data-post="{{ post.ID }}"
-                                    data-name="{{ post.title }}"
-                                    data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                            {% include 'partial/excursion-waiting-actions.twig' %}
                         {% else %}
                             <span class="excursion-signup-waiting"
                                     data-post="{{ post.ID }}"
@@ -91,10 +85,7 @@
                                 <p><small>Mjesto rezervirano za tečajce.</small></p>
                             {% endif %}
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% endif %}
                         
                         {# Priority 2: Leaders can sign up if leader spots remain #}
@@ -105,10 +96,7 @@
                                     data-date="{{ meta.starttime|date('j.n.Y.') }}">Prijava</button>
                             <p><small>Mjesto rezervirano za voditelje.</small></p>
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% endif %}
                         
                         {# Priority 3: Block non-leaders if only leader spots remain #}
@@ -116,10 +104,7 @@
                             <button class="course-disabled-button">Rezervirano za voditelje</button>
                             <p><small>Preostala mjesta rezervirana za voditelje.</small></p>
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% else %}
                                 <span class="excursion-signup-waiting"
                                         data-post="{{ post.ID }}"
@@ -132,10 +117,7 @@
                             <button class="course-disabled-button">Rezervirano</button>
                             <p><small>Preostala mjesta rezervirana za tečajce: {{ reserved_course.category }} ({{ reserved_course.starttime|date('j.m.Y') }} - {{ reserved_course.endtime|date('j.m.Y') }})</small></p>
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% else %}
                                 <span class="excursion-signup-waiting"
                                         data-post="{{ post.ID }}"
@@ -162,10 +144,7 @@
                                 <button class="course-disabled-button">Popunjen</button>
                             {% endif %}
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% elseif user_waiting_position == 0 and generalSpots > 0 %}
                                 <span class="excursion-signup-waiting"
                                         data-post="{{ post.ID }}"
@@ -180,10 +159,7 @@
                                     data-name="{{ post.title }}"
                                     data-date="{{ meta.starttime|date('j.n.Y.') }}">Prijava</button>
                             {% if post.ID in signups.excursions_waiting %}
-                                <span class="excursion-signout-waiting"
-                                        data-post="{{ post.ID }}"
-                                        data-name="{{ post.title }}"
-                                        data-date="{{ meta.starttime|date('j.n.Y.') }}">Odjavi se sa liste interesa</span>
+                                {% include 'partial/excursion-waiting-actions.twig' %}
                             {% endif %}
                         
                         {# Fallback #}


### PR DESCRIPTION
Adds an optional email notifier if a user is on the waiting list and space on the excursion opens up.

I am marking this as draft because it's a bit bigger feature and it would be useful to get another pair of eyes on this. Also I had to hack email sending in order to be able to test locally. Let me know is there a better way to test this. Anyhow, here are few screenshots of the new flow.

Here is the new modal we get after signing up for a waiting list.

<img width="798" height="446" alt="2026-06-14_21:46:20" src="https://github.com/user-attachments/assets/71a6cea9-0d69-4f9b-ae90-b9294ce78b1f" />

If a user selected a checkbox we're marking him with the "notify" flag and the UI will have a :bell:. Admitedly, :bell: and :no_bell: could be confusing so to minimize that we have a tooltip that says "Uključi/Isključi obavijesti e-mailom".

If a space on the excursion opens up, all of the users on the waiting list will get this email:
```
Content-Transfer-Encoding: 8bit
Content-Type: text/plain; charset=UTF-8
Date: Sun, 14 Jun 2026 19:46:45 +0000
From: RK Geronimo <admin@rkg-geronimo.hr>
MIME-Version: 1.0
Message-ID: <86AqTz1w5jL7wct3sCP9kRDCjzJ6RJxDaTCRPxllkHk@localhost>
Received: from localhost by mailhog.example (MailHog)
          id 9Xi5zzo-BHNUyxVFMQDj-X7y2lBYf-UsDNRx-kKQHnU=@mailhog.example; Sun, 14 Jun 2026 19:46:45 +0000
Return-Path: <admin@rkg-geronimo.hr>
Subject: =?us-ascii?Q?RK_Geronimo_-_Oslobodilo_se_mjesto_za_izlet:_Te?= =?us-ascii?Q?stni_izlet_za_slanje_mailova?=
To: test@test.com
X-Mailer: PHPMailer 7.0.0 (https://github.com/PHPMailer/PHPMailer)

Bok!

Oslobodilo se mjesto za izlet "Testni izlet za slanje mailova". Ako i dalje želiš ići možeš se prijaviti na poveznici:
http://localhost:8080/izlet/testni-izlet-za-slanje-mailova/

Tvoj,
RKG web
```

Cc: @morrigan @mholi21 