### PR TITLE
fix: remove user's guests when unregistering from excursion

### DIFF
--- a/src/js/theme/modal.js
+++ b/src/js/theme/modal.js
@@ -635,8 +635,12 @@ $('.excursion-signout').on('click', (e) => {
     signup = 'course';
     const signupId = $(e.currentTarget).data('post');
     const signoutName = $(e.currentTarget).data('name');
+    const hasGuests = $(e.currentTarget).data('has-guests');
     $('input[name="signout-excursion"]').val(signupId);
     $('.excursion-signout-name').text(signoutName);
+    // Only warn about guest removal when the user actually has guests
+    // registered for this excursion (data-has-guests is emitted by single-excursion.twig).
+    $('.excursion-signout-guest-note').toggle(hasGuests === '1' || hasGuests === 1);
     jQuery.post(rkgTheme.ajaxurl, loginStatus, (response) => {
         if (response === 'yes') {
             modalOpen('#excursion-signout-form');

--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -355,9 +355,39 @@ function rkg_excursion_signout()
     );
 
     if ($result) {
-        $tableName = $wpdb->prefix."rkg_excursion_meta";
-        $wpdb->query("UPDATE $tableName SET registered = registered - 1 WHERE id = {$info['post']};");
-    
+        $metaTableName = $wpdb->prefix."rkg_excursion_meta";
+        $wpdb->query("UPDATE $metaTableName SET registered = registered - 1 WHERE id = {$info['post']};");
+
+        $guestTableName = $wpdb->prefix."rkg_excursion_guest";
+        $excursionMeta = $wpdb->get_row($wpdb->prepare(
+            "SELECT guests_limit FROM $metaTableName WHERE id = %d",
+            $info['post']
+        ));
+
+        $guestCount = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM $guestTableName WHERE post_id = %d AND user_id = %d",
+            $info['post'],
+            $currentUser->ID
+        ));
+
+        if ($guestCount > 0) {
+            $wpdb->delete(
+                $guestTableName,
+                array(
+                    'user_id' => $currentUser->ID,
+                    'post_id' => $info['post'],
+                )
+            );
+
+            if (!empty($excursionMeta->guests_limit)) {
+                $wpdb->query($wpdb->prepare(
+                    "UPDATE $metaTableName SET registered = registered - %d WHERE id = %d",
+                    $guestCount,
+                    $info['post']
+                ));
+            }
+        }
+
         echo json_encode(array('update'=>true, 'message'=>__('odjava uspješna')));
         wp_die();
     }

--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -358,12 +358,9 @@ function rkg_excursion_signout()
         $metaTableName = $wpdb->prefix."rkg_excursion_meta";
         $wpdb->query("UPDATE $metaTableName SET registered = registered - 1 WHERE id = {$info['post']};");
 
+        // When the user leaves an excursion, any guests they registered must
+        // be removed too. First count the user's guests for this excursion.
         $guestTableName = $wpdb->prefix."rkg_excursion_guest";
-        $excursionMeta = $wpdb->get_row($wpdb->prepare(
-            "SELECT guests_limit FROM $metaTableName WHERE id = %d",
-            $info['post']
-        ));
-
         $guestCount = (int) $wpdb->get_var($wpdb->prepare(
             "SELECT COUNT(*) FROM $guestTableName WHERE post_id = %d AND user_id = %d",
             $info['post'],
@@ -371,6 +368,7 @@ function rkg_excursion_signout()
         ));
 
         if ($guestCount > 0) {
+            // Delete all of the user's guests for this excursion.
             $wpdb->delete(
                 $guestTableName,
                 array(
@@ -378,6 +376,15 @@ function rkg_excursion_signout()
                     'post_id' => $info['post'],
                 )
             );
+
+            // Guests only count towards the "registered" total when the
+            // excursion enforces a guest limit (guest sign-up in Users.php
+            // mirrors this). So only decrement "registered" by the number of
+            // removed guests in that case, otherwise the count would drift.
+            $excursionMeta = $wpdb->get_row($wpdb->prepare(
+                "SELECT guests_limit FROM $metaTableName WHERE id = %d",
+                $info['post']
+            ));
 
             if (!empty($excursionMeta->guests_limit)) {
                 $wpdb->query($wpdb->prepare(

--- a/web/app/themes/rkg-theme/templates/partial/modals.twig
+++ b/web/app/themes/rkg-theme/templates/partial/modals.twig
@@ -106,6 +106,7 @@
         <form class="form-horizontal course-signout-form" id="excursion-signout-form" role="form">
             <p>Ne želiš roniti s nama?</p>
             <p>Odjavljuješ se sa izleta: "<span class="excursion-signout-name"></span>"</p>
+            <p class="excursion-signout-guest-note" style="display:none;">Tvoji gosti na ovom izletu bit će automatski odjavljeni.</p>
             <input type="hidden" name="signout-excursion" id="signout-excursion" value="" />
             <input type="submit" class="btn btn-primary" id="btn-signout-excursion" value="Odjava" />
         </form>

--- a/web/app/themes/rkg-theme/templates/single-excursion.twig
+++ b/web/app/themes/rkg-theme/templates/single-excursion.twig
@@ -53,7 +53,8 @@
                     {% elseif post.ID in signups.excursions %}
                         <button class="excursion-signout course-signout-button"
                                 data-post="{{ post.ID }}"
-                                data-name="{{ post.title }}">Odjava</button>
+                                data-name="{{ post.title }}"
+                                data-has-guests="{{ myGuests is not empty ? '1' : '0' }}">Odjava</button>
                     {% elseif meta.deadline < now|date('Y-m-d') %}
                         <button class="course-disabled-button">Zaključan</button>
                         {% if post.ID in signups.excursions_waiting %}


### PR DESCRIPTION
  When a user signs out of an excursion, their registered guests are now
  also removed from rkg_excursion_guest. The registered counter is
  decremented for each removed guest when guests_limit is enabled.

  The sign-out confirmation modal now shows a note about guest removal
  when the user has guests registered.