### PR TITLE
Fix/security authz csrf remaining

### DIFF
--- a/src/js/theme/modal.js
+++ b/src/js/theme/modal.js
@@ -339,6 +339,7 @@ $('form#additional-details-form').on('submit', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'rkg_user_additional_details',
+            nonce: rkgTheme.nonce,
             pob: $('form#additional-details-form #pob').val(),
             dob: $('form#additional-details-form #dob').val(),
             oib: $('form#additional-details-form #oib').val(),
@@ -694,6 +695,7 @@ $('form#excursion-signout-form').on('submit', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'rkg_excursion_signout',
+            nonce: rkgTheme.nonce,
             post: $('form#excursion-signout-form #signout-excursion').val(),
         },
         success: (data) => {
@@ -712,6 +714,7 @@ $('form#excursion-signout-waiting-form').on('submit', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'rkg_excursion_signout_waiting',
+            nonce: rkgTheme.nonce,
             post: $('form#excursion-signout-form #signout-excursion').val(),
         },
         success: (data) => {
@@ -726,6 +729,7 @@ $('form#gear-form').on('submit', (e) => {
     e.preventDefault();
     const formData  = new FormData($('#gear-form').get(0));
     formData.append('action', 'gear_reserve');
+    formData.append('nonce', rkgTheme.nonce);
 
     jQuery.ajax({
         url: rkgTheme.ajaxurl,
@@ -751,6 +755,7 @@ $('#no-gear').on('click', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'gear_reserve_no',
+            nonce: rkgTheme.nonce,
             post: gearId,
         },
         success: () => {
@@ -768,6 +773,7 @@ $('form#excursion-guest-form').on('submit', (e) => {
     e.preventDefault();
     const formData  = new FormData($('#excursion-guest-form').get(0));
     formData.append('action', 'guest_invite');
+    formData.append('nonce', rkgTheme.nonce);
 
     jQuery.ajax({
         url: rkgTheme.ajaxurl,
@@ -797,6 +803,7 @@ $('form#excursion-guest-remove-form').on('submit', (e) => {
     e.preventDefault();
     const formData  = new FormData($('#excursion-guest-remove-form').get(0));
     formData.append('action', 'guest_uninvite');
+    formData.append('nonce', rkgTheme.nonce);
 
     jQuery.ajax({
         url: rkgTheme.ajaxurl,
@@ -822,6 +829,7 @@ $('.course-interested').on('click', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'course_interest',
+            nonce: rkgTheme.nonce,
             course,
         },
         success() {
@@ -842,6 +850,7 @@ $('.course-not-interested').on('click', (e) => {
         url: rkgTheme.ajaxurl,
         data: {
             action: 'course_not_interest',
+            nonce: rkgTheme.nonce,
             course,
         },
         success() {

--- a/src/js/theme/site.js
+++ b/src/js/theme/site.js
@@ -178,6 +178,7 @@ jQuery(document).ready(($) => {
             url: rkgTheme.ajaxurl,
             data: {
                 action: 'rkg_course_signout',
+                nonce: rkgTheme.nonce,
                 course: $('form#course-signout-form #signout-course').val(),
             },
             success: (data) => {

--- a/web/app/plugins/rkg-plugin/lib/Courses.php
+++ b/web/app/plugins/rkg-plugin/lib/Courses.php
@@ -126,6 +126,10 @@ class Courses implements InitInterface
         $id = intval($context['request']->get['post']);
         $context['post'] = new Timber\Post($id);
 
+        if ($context['request']->post && !current_user_can('edit_courses')) {
+            wp_die('Nedovoljna prava', 403);
+        }
+
         $context['participants'] = array();
         $tableName = $wpdb->prefix."rkg_course_signup";
         $participants = $wpdb->get_results(
@@ -645,8 +649,9 @@ class Courses implements InitInterface
     public function courseInterestPage()
     {
         $context            = Timber::get_context();
-        if(!current_user_can('edit_course')) {
+        if(!current_user_can('edit_courses')) {
             Timber::render('single-no-pasaran.twig', $context);
+            return;
         }
 
         $tableName          = $this->wpdb->prefix."rkg_course_interest";

--- a/web/app/plugins/rkg-plugin/lib/Users.php
+++ b/web/app/plugins/rkg-plugin/lib/Users.php
@@ -46,7 +46,6 @@ class Users implements InitInterface
         add_action('wp_ajax_profile_picture_upload', array($this, 'profilePictureUpload'));
 
         add_action('wp_ajax_health_survey', array($this, 'helthSurvey'));
-        add_action('wp_ajax_nopriv_helth_survey', array($this, 'helthSurvey'));
 
         add_action('profile_update', array($this, 'updateUserName'));
 
@@ -60,16 +59,12 @@ class Users implements InitInterface
         );
 
         add_action('wp_ajax_gear_reserve', array($this, 'gearReserve'));
-        add_action('wp_ajax_nopriv_gear_reserve', array($this, 'gearReserve'));
 
         add_action('wp_ajax_gear_reserve_no', array($this, 'gearReserveNo'));
-        add_action('wp_ajax_nopriv_gear_reserve_no', array($this, 'gearReserveNo'));
 
         add_action('wp_ajax_guest_invite', array($this, 'guestInvite'));
-        add_action('wp_ajax_nopriv_guest_invite', array($this, 'guestInvite'));
 
         add_action('wp_ajax_guest_uninvite', array($this, 'guestUninvite'));
-        add_action('wp_ajax_nopriv_guest_uninvite', array($this, 'guestUninvite'));
     }
 
     public function createMemberRegistry()
@@ -629,6 +624,9 @@ class Users implements InitInterface
      */
     public function gearReserve()
     {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('Not authorized');
+        }
 
         $currentUser = wp_get_current_user();
         $userId = $currentUser->ID;
@@ -671,6 +669,10 @@ class Users implements InitInterface
      */
     public function gearReserveNo()
     {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('Not authorized');
+        }
+
         $currentUser = wp_get_current_user();
 
         global $wpdb;
@@ -695,6 +697,10 @@ class Users implements InitInterface
      */
     public function guestInvite()
     {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('Not authorized');
+        }
+
         global $wpdb;
 
         $postId = intval($_POST['post']);
@@ -750,6 +756,9 @@ class Users implements InitInterface
      */
     public function guestUninvite()
     {
+        if (!is_user_logged_in()) {
+            wp_send_json_error('Not authorized');
+        }
 
         $currentUser = wp_get_current_user();
 
@@ -858,6 +867,7 @@ class Users implements InitInterface
         $context            = Timber::get_context();
         if(!current_user_can('edit_users')) {
             Timber::render('single-no-pasaran.twig', $context);
+            return;
         }
 
         global $wpdb;

--- a/web/app/plugins/rkg-plugin/lib/Users.php
+++ b/web/app/plugins/rkg-plugin/lib/Users.php
@@ -627,6 +627,7 @@ class Users implements InitInterface
         if (!is_user_logged_in()) {
             wp_send_json_error('Not authorized');
         }
+        check_ajax_referer('rkg', 'nonce');
 
         $currentUser = wp_get_current_user();
         $userId = $currentUser->ID;
@@ -672,6 +673,7 @@ class Users implements InitInterface
         if (!is_user_logged_in()) {
             wp_send_json_error('Not authorized');
         }
+        check_ajax_referer('rkg', 'nonce');
 
         $currentUser = wp_get_current_user();
 
@@ -700,6 +702,7 @@ class Users implements InitInterface
         if (!is_user_logged_in()) {
             wp_send_json_error('Not authorized');
         }
+        check_ajax_referer('rkg', 'nonce');
 
         global $wpdb;
 
@@ -759,6 +762,7 @@ class Users implements InitInterface
         if (!is_user_logged_in()) {
             wp_send_json_error('Not authorized');
         }
+        check_ajax_referer('rkg', 'nonce');
 
         $currentUser = wp_get_current_user();
 

--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -90,6 +90,7 @@ function rkg_user_additional_details()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $info              = array();
     $info['dob']       = date('Y-m-d', strtotime($_POST['dob']));
@@ -158,6 +159,7 @@ function rkg_course_interest_signup()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $course      = $_POST['course'];
     $currentUser = wp_get_current_user();
@@ -185,6 +187,7 @@ function rkg_course_not_interest_signup()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $course      = $_POST['course'];
     $currentUser = wp_get_current_user();
@@ -333,6 +336,7 @@ function rkg_course_signout()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $info           = array();
     $info['course'] = $_POST['course'];
@@ -370,6 +374,7 @@ function rkg_excursion_signout()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $info           = array();
     $info['post'] = $_POST['post'];
@@ -444,6 +449,7 @@ function rkg_excursion_signout_waiting()
     if (!is_user_logged_in()) {
         wp_send_json_error('Not authorized');
     }
+    check_ajax_referer('rkg', 'nonce');
 
     $info           = array();
     $info['post'] = $_POST['post'];

--- a/web/app/themes/rkg-theme/functions.php
+++ b/web/app/themes/rkg-theme/functions.php
@@ -87,6 +87,10 @@ add_action('wp_ajax_nopriv_is_user_logged_in', 'ajax_check_user_logged_in');
 
 function rkg_user_additional_details()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $info              = array();
     $info['dob']       = date('Y-m-d', strtotime($_POST['dob']));
     $info['pob']       = sanitize_text_field($_POST['pob']);
@@ -148,10 +152,13 @@ function rkg_user_additional_details()
 }
 
 add_action('wp_ajax_rkg_user_additional_details', 'rkg_user_additional_details');
-add_action('wp_ajax_nopriv_rkg_user_additional_details', 'rkg_user_additional_details');
 
 function rkg_course_interest_signup()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $course      = $_POST['course'];
     $currentUser = wp_get_current_user();
 
@@ -172,10 +179,13 @@ function rkg_course_interest_signup()
 }
 
 add_action('wp_ajax_course_interest', 'rkg_course_interest_signup');
-add_action('wp_ajax_nopriv_course_interest', 'rkg_course_interest_signup');
 
 function rkg_course_not_interest_signup()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $course      = $_POST['course'];
     $currentUser = wp_get_current_user();
 
@@ -195,7 +205,6 @@ function rkg_course_not_interest_signup()
 }
 
 add_action('wp_ajax_course_not_interest', 'rkg_course_not_interest_signup');
-add_action('wp_ajax_nopriv_course_not_interest', 'rkg_course_not_interest_signup');
 
 function rkg_user_excursion_signup()
 {
@@ -321,6 +330,10 @@ add_action('wp_ajax_rkg_user_excursion_signup_waiting', 'rkg_user_excursion_sign
 
 function rkg_course_signout()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $info           = array();
     $info['course'] = $_POST['course'];
 
@@ -351,10 +364,13 @@ function rkg_course_signout()
 }
 
 add_action('wp_ajax_rkg_course_signout', 'rkg_course_signout');
-add_action('wp_ajax_nopriv_rkg_course_signout', 'rkg_course_signout');
 
 function rkg_excursion_signout()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $info           = array();
     $info['post'] = $_POST['post'];
 
@@ -422,10 +438,13 @@ function rkg_excursion_signout()
 }
 
 add_action('wp_ajax_rkg_excursion_signout', 'rkg_excursion_signout');
-add_action('wp_ajax_nopriv_rkg_excursion_signout', 'rkg_excursion_signout');
 
 function rkg_excursion_signout_waiting()
 {
+    if (!is_user_logged_in()) {
+        wp_send_json_error('Not authorized');
+    }
+
     $info           = array();
     $info['post'] = $_POST['post'];
 
@@ -452,13 +471,15 @@ function rkg_excursion_signout_waiting()
 }
 
 add_action('wp_ajax_rkg_excursion_signout_waiting', 'rkg_excursion_signout_waiting');
-add_action('wp_ajax_nopriv_rkg_excursion_signout_waiting', 'rkg_excursion_signout_waiting');
 
 if(is_admin()){
   remove_action("admin_color_scheme_picker", "admin_color_scheme_picker");
 }
 
 add_filter('show_admin_bar', '__return_false');
+
+// Hide the WordPress version from the generator meta tag
+remove_action('wp_head', 'wp_generator');
 
 add_action( 'admin_menu', 'Wps_remove_tools', 99 );
 function Wps_remove_tools(){

--- a/web/app/themes/rkg-theme/lib/RKGTheme.php
+++ b/web/app/themes/rkg-theme/lib/RKGTheme.php
@@ -78,6 +78,7 @@ class RKGTheme
             'rkgTheme',
             array(
                 'ajaxurl'        => admin_url('admin-ajax.php'),
+                'nonce'          => wp_create_nonce('rkg'),
             )
         );
     }


### PR DESCRIPTION
Title: fix(security): enforce AJAX authorization and add CSRF nonce

---

Follow-up to `fd53d30` (Close XSS paths). That commit closed the stored-XSS output-escaping and input-sanitization findings from `SECURITY_REVIEW.md` (#1, and the sanitization half of #2). This PR closes the remaining authorization and CSRF findings. XSS (#1) and SQL injection are already handled on `main`.

## Fixes

### Authorization (#2 login, #3, #4)
- `Courses.php`: gate the POST write path of `showCourseReport()` behind `current_user_can('edit_courses')` so read-only users can no longer overwrite course meta / card numbers; add missing `return` after the access-denied render in `courseInterestPage()`; normalize `edit_course` → `edit_courses`.
- `Users.php`: add `is_user_logged_in()` guards to `gearReserve` / `gearReserveNo` / `guestInvite` / `guestUninvite`; drop their `wp_ajax_nopriv_*` registrations and the misspelled `wp_ajax_nopriv_helth_survey`; add missing `return` in `memberRegistryPage()`.
- theme `functions.php`: add `is_user_logged_in()` guards to the six writing AJAX handlers and remove their `nopriv` registrations. Registration/login/status/calendar stay public.

### CSRF nonce (#5)
- Wire a single `rkg` nonce end-to-end across the 10 member-facing AJAX actions: localized via `wp_create_nonce('rkg')` in `RKGTheme.php`, sent from all 10 callers in the JS source (`src/js/theme/modal.js`, `src/js/theme/site.js`), verified with `check_ajax_referer('rkg', 'nonce')` in every handler.

### Version disclosure (#6, code portion)
- `remove_action('wp_head', 'wp_generator')` to hide the WP version. The Apache `ServerTokens`/`ServerSignature` part is server config, out of scope for this PR.

## Notes for the reviewer
- Two commits, deliberately separable: authorization (low risk) and CSRF nonce (needs a smoke test). The nonce commit can be reviewed/reverted independently.
- The CSRF nonce changes could **not** be runtime-tested in my environment (no PHP / running stack). Built `static/site.js` is gitignored; run `gulp scriptsTheme` on deploy and smoke-test the 10 member flows (course interest/signout, excursion signout + waiting, gear reserve/cancel, guest invite/uninvite, additional details) before merging.
- Not addressed here: the non-security `shirt_size` seed/migration bug noted at the end of `SECURITY_REVIEW.md`.

**Security concerns:** Anonymous `nopriv` AJAX write access and a read-only-to-write course privilege escalation are closed; nonce protection added but requires a pre-merge smoke test.
